### PR TITLE
License, issue templates, other minor fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,46 @@
+---
+name: Bug Report
+about: Report problems with the OpenDI site, its content, or its deployment processes
+title: 'Bug: [Brief title here]'
+labels: bug, community submission
+assignees: ''
+
+---
+
+## Reminders
+(To save space, you may delete this section of the template before submitting your issue)
+
+Please submit your feedback to the most relevant repository:
+- [opendi-org/landing-site](https://github.com/opendi-org/landing-site) for general OpenDI feedback, or feedback related to the OpenDI homepage and related content
+- [opendi-org/roles-user-stories](https://github.com/opendi-org/roles-user-stories) for feedback related to the OpenDI roles and user stories
+- [opendi-org/json-schema](https://github.com/opendi-org/json-schema) for feedback related to the OpenDI JSON Schema
+
+**Always use the Issue search feature to see if your report, request, or feedback already exists!**  
+If your issue already exists, add your voice to the comments section! Provide your unique perspective, additional info, etc.
+
+Please fill in the remaining portions of the template to the best of your ability. This will help us get the most value out of your contributions!
+
+## Describe the bug
+> A clear and concise description of what the bug is.
+
+## Bug category
+> Which category best fits this bug? Please indicate one of the following:
+> - **Content**: Bug concerns the standards content itself (inconsistency, typo, unclear, etc.)
+> - **Site**: Bug concerns the public website (broken link, error 404/missing content, etc.)
+> - **Deployment**: Bug concerns the deployment process (GitHub Actions, mkdocs generation process or configuration, etc.)
+
+## To Reproduce
+> Steps to reproduce the behavior:
+> 1. Go to '...'
+> 2. Click on '....'
+> 3. Scroll down to '....'
+> 4. See error
+
+## Expected behavior
+> A clear and concise description of what you expected to happen.
+
+## Screenshots
+> If applicable, add screenshots to help explain your problem.
+
+## Additional context
+> If applicable, add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/enhancement-request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement-request.md
@@ -1,0 +1,36 @@
+---
+name: Enhancement Request
+about: Suggest an idea, revision, or other enhancement
+title: 'Enhancement: [Brief title here]'
+labels: community submission, enhancement
+assignees: ''
+
+---
+
+## Reminders
+(To save space, you may delete this section of the template before submitting your issue)
+
+Please submit your feedback to the most relevant repository:
+- [opendi-org/landing-site](https://github.com/opendi-org/landing-site) for general OpenDI feedback, or feedback related to the OpenDI homepage and related content
+- [opendi-org/roles-user-stories](https://github.com/opendi-org/roles-user-stories) for feedback related to the OpenDI roles and user stories
+- [opendi-org/json-schema](https://github.com/opendi-org/json-schema) for feedback related to the OpenDI JSON Schema
+
+**Always use the Issue search feature to see if your report, request, or feedback already exists!**  
+If your issue already exists, add your voice to the comments section! Provide your unique perspective, additional info, etc.
+
+Please fill in the remaining portions of the template to the best of your ability. This will help us get the most value out of your contributions!
+
+## Is your enhancement request related to a problem or unique use case? If so, please describe.
+> A clear and concise description of what the problem/use case is.  
+> Ex. My organization's DI use case is [...]
+
+## Describe the enhancement
+> Are you suggesting a rework of existing content, or new content?  
+> How will the suggested enhancement solve your problem or facilitate your use case?  
+> Provide more details about the enhancement here.
+
+## Describe alternatives you've considered
+> If applicable, give a clear and concise description of any alternative solutions you've considered, or how the existing standards relate to your problem or use case.
+
+## Additional context
+> If applicable, add any other context about the enhancement request here.

--- a/.github/ISSUE_TEMPLATE/other-issue.md
+++ b/.github/ISSUE_TEMPLATE/other-issue.md
@@ -1,0 +1,24 @@
+---
+name: Other Issue
+about: For issues not covered by the other issue templates
+title: 'Other: [Brief title here]'
+labels: community submission
+assignees: ''
+
+---
+
+## Reminders
+
+Please review the other available templates before using this template! We will be able to process your issue more efficiently if it can fit into one of the other templates.
+
+For general comments or other high-level feedback, join the [OpenDI Discord server](https://discord.gg/FtAX3JStJz)!
+
+## Why Other
+
+> Briefly explain why you chose this template.  
+> Should we adjust the existing templates? Add a new template? Let us know what you think!
+
+## Issue description
+
+> Describe your issue here.  
+> For guidance on general structure, and on what sort of information is most helpful, see the other issue templates.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 OpenDI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Want to engage in community discussion? Join the [OpenDI Discord server!](https:
 A good way to get familiar with the schema is to browse some test data. See `test-data.json`.  
 Ideally, clone the repo to a dev environment that has JSON Schema integration, like VS Code. See instructions below.
 
-Alternatively, there is static HTML documentation in `docs/schema_docs.html`.  
+Alternatively, browse the docs on the OpenDI website.  
 These docs pull information directly from the schema and presents it in a more readable format. 
 
 ## VS Code


### PR DESCRIPTION
1:
Created MIT license file.
This will show on the home page for this repo once LICENSE is merged to `main`.

2:
Created issue templates. These will be identical to templates in the other repos.
See 9c56499 for details.
Templates will activate once these files are merged to `main`.
Relevant issue labels [have been added](https://github.com/opendi-org/json-schema/labels).

Any updates to these issue templates will need to be manually mirrored to the other repos.

3:
Minor formatting stuff. Updated a README reference.