### PR TITLE
Fix JSON Schema submodule's SSH URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "docs/api-source/schemas"]
 	path = docs/api-source/schemas
-	url = git@github.com:opendi-org/cdm-json-schema.git
+	url = git@github.com/cdm-json-schema.git
 	branch = dev-sourceonly


### PR DESCRIPTION
Submodule unintentionally inherited some local SSH config stuff that was causing GitHub Actions to fail.  
Updated the URL: git@github.com:opendi-org/cdm-json-schema.git -> git@github.com/cdm-json-schema.git

GitHub Actions had no SSH config settings for git@github.com:opendi-org so it could not resolve the previous URL.  
See [this error output](https://github.com/opendi-org/api-specification/actions/runs/20306915214/job/58326784129#step:6:11) from this morning's Action run.